### PR TITLE
docs: add GitHub Copilot instructions

### DIFF
--- a/.github/instructions/code.instructions.md
+++ b/.github/instructions/code.instructions.md
@@ -1,0 +1,36 @@
+---
+applyTo: '**'
+---
+
+# Go Coding & Best Practices
+
+## General Conventions
+- Follow Go idioms (Effective Go, CodeReviewComments).
+- Prioritize clarity, readability, conciseness.
+- **Error Handling:** Use `fmt.Errorf` with `%w`; return errors.
+- **Logging:** Use `zerolog.Logger` with context fields.
+- **Dependencies:** Go Modules (`go.mod`, `go.sum`).
+- **UUIDs:** Use for primary keys.
+
+## GORM & Database
+- GORM models in `infrastructure/.../sql/model.go`.
+- Converters in `.../sql/converter.go`.
+- Access via repository implementations.
+
+## MCP Implementation
+- Tools: `api/mcp/tools.go`.
+- Handlers: `api/mcp/mcp.go`, `internal/<domain>/ports/mcp.go`.
+- Map tools to domain services.
+
+## When Assisting
+- Identify layer: domain, infra, port, api.
+- Keep domain logic pure; infra adapters implement interfaces.
+- Use `config.Config` for config values.
+
+## File Guidance
+- `cmd/main.go`: startup, shutdown.
+- `cmd/di/wire.go`: DI wiring.
+- `config/config.go`: config structure.
+- `internal/*/domain/service.go`: business logic.
+- `internal/*/infra/persistence/repository.go`: data access.
+- `api/mcp/*`: MCP definitions.

--- a/.github/instructions/commit-message.instructions.md
+++ b/.github/instructions/commit-message.instructions.md
@@ -1,0 +1,15 @@
+# Commit Message Instructions
+
+## Format
+Conventional Commits: `type(scope): subject`
+- **type:** feat, fix, docs, style, refactor, test, chore, ci, perf
+- **scope:** (Optional) Module (e.g., `invoices`, `config`)
+- **subject:** Concise, imperative, lowercase.
+
+## Body (Optional)
+- Detailed explanation.
+- Issue numbers (e.g., `Fixes #123`).
+
+## Examples
+- `feat(invoices): add support for partial payments`
+- `fix(config): correct default SSLMode value`

--- a/.github/instructions/documentation.instructions.md
+++ b/.github/instructions/documentation.instructions.md
@@ -1,0 +1,25 @@
+---
+applyTo: '**'
+---
+
+# Documentation Guidelines
+
+## Principles
+- Clarity & conciseness.
+- Audience-aware.
+- Keep docs up to date.
+
+## Code Comments
+- **GoDoc:** For public symbols (what, why).
+- **Inline:** For complex logic.
+
+## README.md
+- Update: overview, setup, config, features, MCP client.
+
+## API Docs
+- Tools: document `api/mcp/tools.go` inputs/outputs.
+- OpenAPI: sync with `api/openapi/`.
+
+## When Assisting
+- Suggest GoDoc and inline comments.
+- Help update README/API docs.

--- a/.github/instructions/pull-request-description.instructions.md
+++ b/.github/instructions/pull-request-description.instructions.md
@@ -1,0 +1,20 @@
+# Pull Request Description Instructions
+
+## Structure
+1.  **Purpose:** What & why? Link issues (e.g., "Closes #123").
+2.  **Changes Made:** Key changes (bullet points).
+3.  **How to Test:** Steps for verification.
+4.  **Screenshots/GIFs (if applicable).**
+5.  **Checklist (Optional):** Docs updated, tests added, etc.
+
+## Tone
+- Clear, concise, professional.
+
+## Example
+**Purpose:**
+This PR introduces invoice archiving. Closes #78.
+
+**Changes Made:**
+- Added `ArchiveInvoice` to `InvoiceService`.
+- Implemented GORM soft-delete.
+- Exposed `archiveInvoice` MCP tool.

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -1,0 +1,33 @@
+---
+applyTo: '**/**_test.go'
+---
+
+# Testing Instructions for Billing MCP Server
+
+## 1. General Testing Principles
+- Write unit tests for new functionality, especially for:
+    - Domain logic (`internal/<domain>/domain/`).
+    - Critical infrastructure components (e.g., repository methods).
+- Place tests in `_test.go` files within the same package as the code being tested.
+- Aim for clear, focused tests that verify specific behaviors.
+
+## 2. Tools & Libraries
+- Use `github.com/stretchr/testify/assert` for non-fatal assertions.
+- Use `github.com/stretchr/testify/require` for assertions that should halt the test on failure.
+
+## 3. What to Test
+- **Domain Services:** Business logic, edge cases, validation.
+- **Repositories:** Mock DB or use test DB to verify queries & mapping.
+- **Converters:** Accurate mapping between domain and infra/API models.
+- **MCP Handlers/Ports:** Request parsing, service calls, response formatting. Mock domain services.
+
+## 4. Best Practices
+- **Isolation:** Keep unit tests isolated. Use mocks/stubs.
+- **Readability:** Descriptive test names.
+- **Coverage:** Good coverage of critical paths.
+- **Maintenance:** Update tests with code changes.
+
+## 5. When Assisting with Tests
+- Suggest/generate tests for new/modified functions.
+- Help identify test cases (positive, negative, edge).
+- Assist in creating mocks.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To get started with the Billing MCP Server, follow these steps:
 
 4. Run the server:
    ```bash
-   go run main.go
+   go run cmd/main.go
    ```
 
 ## Configuration


### PR DESCRIPTION
This PR adds GitHub Copilot instruction files to enhance code assistance across the codebase. 

## Changes
- Added code style and best practices instructions for Go
- Added documentation guidelines
- Added testing instructions
- Added commit message format instructions
- Added PR description instructions
- Updated README with correct command to run the application

These instruction files help GitHub Copilot provide more tailored assistance for our codebase based on our specific architectural patterns and guidelines.